### PR TITLE
Injection label update

### DIFF
--- a/modules/ROOT/pages/eventing-trigger-broker.adoc
+++ b/modules/ROOT/pages/eventing-trigger-broker.adoc
@@ -15,7 +15,7 @@ By labeling `{tutorial-namespace}` namespace with `knative-eventing-injection=en
 [.console-input]
 [source,bash,subs="+macros,+attributes"]
 ----
-kubectl label namespace {tutorial-namespace} knative-eventing-injection=enabled
+kubectl label namespace {tutorial-namespace} eventing.knative.dev/injection=enabled
 ----
 
 


### PR DESCRIPTION
The injection label has changed since eventing 0.16, see https://knative.dev/v0.16-docs/eventing/getting-started/#optional-sugar-controller